### PR TITLE
Add FastAPI endpoints with tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,68 @@
 from fastapi import FastAPI
-app = FastAPI()
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+
+app = FastAPI(
+    title="GenAI Dashboard Backend",
+    description="API for GenAI-powered insights and dashboard interpretations",
+    version="0.1.0",
+)
+
+# Allow CORS from any origin for development convenience
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class ExplanationRequest(BaseModel):
+    """Request body for the /explanation endpoint."""
+
+    rule_id: str
+    timestamp: str
+
+
+class ThresholdRecommendationRequest(BaseModel):
+    """Request body for the /recommend-threshold endpoint."""
+
+    metric_name: str
+    window: str
+
+
+class RuleHitSummaryRequest(BaseModel):
+    """Request body for the /rule-hit-summary endpoint."""
+
+    start_date: str
+    end_date: str
+
 
 @app.get("/")
-def read_root():
-    return {"message": "GenAI Dashboard Backend running"}
+def root():
+    """Basic health check used by the frontend and tests."""
+
+    return {"message": "GenAI Dashboard API is up"}
+
+
+@app.post("/explanation")
+def generate_explanation(req: ExplanationRequest):
+    """Return a stub explanation for a rule at a given timestamp."""
+
+    return {"message": f"Stub explanation for rule {req.rule_id}"}
+
+
+@app.post("/recommend-threshold")
+def recommend_threshold(req: ThresholdRecommendationRequest):
+    """Return a dummy threshold for the supplied metric/window."""
+
+    # Threshold calculation would happen here. For now return a constant.
+    return {"recommended_threshold": 85}
+
+
+@app.post("/rule-hit-summary")
+def rule_hit_summary(req: RuleHitSummaryRequest):
+    """Return a dummy summary of rule hits for the supplied date range."""
+
+    return {"summary": f"Hits from {req.start_date} to {req.end_date}"}

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_root():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "GenAI Dashboard API is up"
+
+
+def test_explanation():
+    payload = {"rule_id": "R123", "timestamp": "2025-07-09T12:00:00Z"}
+    resp = client.post("/explanation", json=payload)
+    assert resp.status_code == 200
+    assert "Stub explanation" in resp.json()["message"]
+
+
+def test_recommend_threshold():
+    payload = {"metric_name": "CPU", "window": "7d"}
+    resp = client.post("/recommend-threshold", json=payload)
+    assert resp.status_code == 200
+    assert "recommended_threshold" in resp.json()
+
+
+def test_rule_hit_summary():
+    payload = {"start_date": "2025-07-01", "end_date": "2025-07-08"}
+    resp = client.post("/rule-hit-summary", json=payload)
+    assert resp.status_code == 200
+    assert "Hits from" in resp.json()["summary"]


### PR DESCRIPTION
## Summary
- expand `backend/main.py` with additional endpoints
- include CORS setup and request models
- add pytest suite covering new API routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686e3c9b27d8833098e88cc16bd26fb9