### PR TITLE
Add basic React UI with routing and API proxy

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,13 +2,19 @@
   "name": "genai-dashboard-ui",
   "version": "1.0.0",
   "scripts": {
-    "start": "vite"
+    "start": "vite",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "vitest": "^0.34.0",
+    "@testing-library/react": "^14.0.0",
+    "jsdom": "^21.1.0",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,17 @@
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import HomePage from './pages/HomePage'
+import DashboardPage from './pages/DashboardPage'
+
+export default function App() {
+  return (
+    <Router>
+      <nav>
+        <Link to="/">Home</Link> | <Link to="/dashboard">Dashboard</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+      </Routes>
+    </Router>
+  )
+}

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import App from './App'
+
+describe('App', () => {
+  it('renders home page and fetches API', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({ message: 'GenAI Dashboard API is up' }) })
+    )
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    )
+    expect(screen.getByText('GenAI Dashboard UI')).toBeInTheDocument()
+    await screen.findByText('GenAI Dashboard API is up')
+  })
+})

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import App from './App'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <h1>GenAI Dashboard UI</h1>
+    <App />
   </React.StrictMode>
 )

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <h2>Dashboard Placeholder</h2>
+}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export default function HomePage() {
+  const [message, setMessage] = useState('Loading...')
+
+  useEffect(() => {
+    fetch('/api/')
+      .then((r) => r.json())
+      .then((data) => setMessage(data.message))
+      .catch(() => setMessage('Error connecting to API'))
+  }, [])
+
+  return (
+    <div>
+      <h1>GenAI Dashboard UI</h1>
+      <p>{message}</p>
+    </div>
+  )
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/api/, '')
+      }
+    }
+  },
+  test: {
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- add React Router and App skeleton with two pages
- integrate Home page with backend API
- add vite config with proxy and vitest config
- set up testing dependencies and example test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `yarn test` *(fails: this package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686e3ebf7e3c8330a855f398cbc87f11